### PR TITLE
Potential fix for code scanning alert no. 9: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,5 +1,7 @@
 # https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-python
 name: CI
+permissions:
+  contents: read
 
 on:
   push: ~


### PR DESCRIPTION
Potential fix for [https://github.com/todofixthis/filters-pydantic/security/code-scanning/9](https://github.com/todofixthis/filters-pydantic/security/code-scanning/9)

To fix the problem, explicitly restrict the `GITHUB_TOKEN` permissions in this workflow. The least-privilege baseline for a workflow that only checks out code and runs tests/docs locally is `contents: read` at the workflow root, so all jobs inherit read-only repository access and no write scopes.

The best fix without changing existing functionality is:
- Add a top-level `permissions` block under `name: CI` (and above `on:`) with `contents: read`.
- This applies to all three jobs (`test`, `type-check`, `docs`) since none define their own permissions.
- No other scopes (issues, pull-requests, packages, etc.) are needed because the jobs do not call GitHub APIs for writes; they only use `actions/checkout` and local commands.

Concretely, in `.github/workflows/build.yml`, insert:

```yaml
permissions:
  contents: read
```

between lines 2 and 4. No additional imports, methods, or definitions are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
